### PR TITLE
fix: missing option for direct scanout

### DIFF
--- a/.config/hypr/UserConfigs/UserSettings.conf
+++ b/.config/hypr/UserConfigs/UserSettings.conf
@@ -136,7 +136,7 @@ misc {
   mouse_move_enables_dpms = true
   #vrr = 0
   enable_swallow = true
-  no_direct_scanout = true #for fullscreen games
+  #no_direct_scanout = true #for fullscreen games
   focus_on_activate = false
   swallow_regex = ^(kitty)$
   #disable_autoreload = true


### PR DESCRIPTION
this merge fixes the direct_scanout option drop from hyprland